### PR TITLE
BUILD: Remove suffixed links on uninstall

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -128,6 +128,18 @@ install-exec-hook:
 		done; \
 	fi
 
+uninstall-hook:
+	@if test -n "$(UCX_LIBRARY_FILE_SUFFIX)"; then \
+		for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(moduledir)"; do \
+			if test -d "$$dir"; then \
+				for link in "$$dir"/*$(UCX_LIBRARY_FILE_SUFFIX).so; do \
+					test -L "$$link" || continue; \
+					$(RM) "$$link"; \
+				done; \
+			fi; \
+		done; \
+	fi
+
 DOCLIST = docs/doxygen/doxygen-doc/ucx.tag
 
 FORMAT = pdf


### PR DESCRIPTION
Adds a matching uninstall hook for the suffixed .so links created by the install hook.

The install hook creates linker aliases in both libdir and moduledir when UCX_LIBRARY_FILE_SUFFIX is set. Since those aliases are created manually, Automake cannot remove them from its generated uninstall rules. The new uninstall hook removes the generated suffix aliases from both directories and limits cleanup to symlinks.

Validation:
- git diff --check
- shell smoke test covering generated symlink cleanup, including broken symlinks after target removal